### PR TITLE
Improve on unit and integration test coverage

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,7 +44,7 @@ func (c *Client) sendRequest(req *http.Request, v interface{}) error {
 	}
 
 	if err = json.NewDecoder(res.Body).Decode(v); err != nil {
-		return fmt.Errorf("decodeing response %v", err)
+		return fmt.Errorf("decode error %v", err)
 	}
 
 	return nil

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,40 @@
+package stormglass
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewClient(t *testing.T) {
+	t.Run("should return default client", func(t *testing.T) {
+		client := NewClient(testKey)
+		assert.NotNil(t, client)
+		assert.Equal(t, client.BaseURL, BaseURLV2)
+		assert.NotNil(t, client.HTTPClient)
+	})
+}
+
+func TestClientSendRequest(t *testing.T) {
+	t.Run("test error status code", func(t *testing.T) {
+		assert := assert.New(t)
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			want := `{"errors:{"key", "Unauthorized – Your API key is invalid."}}`
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(want))
+		}))
+		defer ts.Close()
+
+		c := NewClient(testKey)
+		c.BaseURL = ts.URL
+		c.HTTPClient = ts.Client()
+
+	})
+	t.Run("test decode error", func(t *testing.T) {
+
+	})
+	t.Run("success", func(t *testing.T) {
+
+	})
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,10 +1,11 @@
 package stormglass
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewClient(t *testing.T) {
@@ -18,9 +19,8 @@ func TestNewClient(t *testing.T) {
 
 func TestClientSendRequest(t *testing.T) {
 	t.Run("test error status code", func(t *testing.T) {
-		assert := assert.New(t)
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			want := `{"errors:{"key", "Unauthorized – Your API key is invalid."}}`
+			want := `{"errors":{"key":"API key is invalid"}}`
 			w.WriteHeader(http.StatusUnauthorized)
 			w.Write([]byte(want))
 		}))
@@ -30,11 +30,48 @@ func TestClientSendRequest(t *testing.T) {
 		c.BaseURL = ts.URL
 		c.HTTPClient = ts.Client()
 
+		req, _ := http.NewRequest("GET", ts.URL, nil)
+		err := c.sendRequest(req, nil)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "API key is invalid")
 	})
 	t.Run("test decode error", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			want := `{{`
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(want))
+		}))
+		defer ts.Close()
 
+		c := NewClient(testKey)
+		c.BaseURL = ts.URL
+		c.HTTPClient = ts.Client()
+
+		req, _ := http.NewRequest("GET", ts.URL, nil)
+		err := c.sendRequest(req, nil)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "decode error")
 	})
+
 	t.Run("success", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			want := `{ "name": "test" }`
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(want))
+		}))
+		defer ts.Close()
 
+		c := NewClient(testKey)
+		c.BaseURL = ts.URL
+		c.HTTPClient = ts.Client()
+
+		var obj struct {
+			Name string `json:"name"`
+		}
+		req, _ := http.NewRequest("GET", ts.URL, nil)
+		err := c.sendRequest(req, &obj)
+		assert.Nil(t, err)
+		assert.Equal(t, obj.Name, "test")
 	})
+
 }

--- a/error.go
+++ b/error.go
@@ -27,6 +27,7 @@ func NewError(resp *http.Response) error {
 		StatusCode: resp.StatusCode,
 		Errors:     map[string]interface{}{},
 	}
+
 	data, err := ioutil.ReadAll(resp.Body)
 	if err == nil && data != nil {
 		if err := json.Unmarshal(data, &apiErr); err != nil {

--- a/integration_tests/waether_test.go
+++ b/integration_tests/waether_test.go
@@ -5,7 +5,6 @@ package integration_tests_test
 
 import (
 	"context"
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -46,9 +45,6 @@ func TestGetPoint(t *testing.T) {
 		tme := time.Now().In(time.UTC)
 		var start = now.New(tme).BeginningOfDay()
 		var end = now.New(tme).BeginningOfDay().Add(time.Hour * 23) // api returns hours ahead
-
-		loc := start.Location()
-		log.Println(loc)
 
 		c := stormglass.NewClient(os.Getenv("STORMGLASS_API_KEY"))
 

--- a/integration_tests/waether_test.go
+++ b/integration_tests/waether_test.go
@@ -1,14 +1,12 @@
+//go:build integration
 // +build integration
 
 package integration_tests_test
 
 import (
 	"context"
-	"os"
-	"testing"
-	"time"
-
 	"github.com/jinzhu/now"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	stormglass "github.com/yawlhead91/stormglassgo"
@@ -40,33 +38,33 @@ func TestGetPoint(t *testing.T) {
 		assert.NotNil(t, err, "expecting non-nil error")
 		assert.Equal(t, "403: key:API key is invalid", err.Error(), "unexpected error")
 	})
-	t.Run("success: return 24 hour points", func(t *testing.T) {
-		var start = now.BeginningOfDay()
-		var end = now.BeginningOfDay().Add(time.Hour * 23) // api returns hours ahead
-
-		c := stormglass.NewClient(os.Getenv("STORMGLASS_API_KEY"))
-
-		params := stormglass.ParamsOptions{
-			AirTemperature: true,
-		}
-
-		ctx := context.Background()
-		res, err := c.GetPoint(ctx, stormglass.PointsRequestOptions{
-			Lat:    lat,
-			Lng:    lng,
-			Params: params,
-			Start:  &start,
-			End:    &end,
-		})
-
-		assert.Nil(t, err, "expecting nil response")
-		assert.NotNil(t, res, "expecting non-nil response")
-		assert.Equal(t, 24, len(res.Hours), "unexpected hour point count")
-		assert.NotNil(t, res.Meta, "expecting non-nil response")
-		assert.Equal(t, res.Meta.Cost, 1, "unexpected meta value for cost")
-		assert.Equal(t, start.Format("2006-01-02 15:04"), res.Meta.Start, "unexpected meta value for start")
-		assert.Equal(t, end.Format("2006-01-02 15:04"), res.Meta.End, "unexpected meta value for end")
-		assert.Equal(t, lat, res.Meta.Lat, "unexpected meta value for latitude")
-		assert.Equal(t, lng, res.Meta.Lng, "unexpected meta value for longitude")
-	})
+	//t.Run("success: return 24 hour points", func(t *testing.T) {
+	//	var start = now.BeginningOfDay()
+	//	var end = now.BeginningOfDay().Add(time.Hour * 23) // api returns hours ahead
+	//
+	//	c := stormglass.NewClient(os.Getenv("STORMGLASS_API_KEY"))
+	//
+	//	params := stormglass.ParamsOptions{
+	//		AirTemperature: true,
+	//	}
+	//
+	//	ctx := context.Background()
+	//	res, err := c.GetPoint(ctx, stormglass.PointsRequestOptions{
+	//		Lat:    lat,
+	//		Lng:    lng,
+	//		Params: params,
+	//		Start:  &start,
+	//		End:    &end,
+	//	})
+	//
+	//	assert.Nil(t, err, "expecting nil response")
+	//	assert.NotNil(t, res, "expecting non-nil response")
+	//	assert.Equal(t, 24, len(res.Hours), "unexpected hour point count")
+	//	assert.NotNil(t, res.Meta, "expecting non-nil response")
+	//	assert.Equal(t, res.Meta.Cost, 1, "unexpected meta value for cost")
+	//	assert.Equal(t, start.Format("2006-01-02 15:04"), res.Meta.Start, "unexpected meta value for start")
+	//	assert.Equal(t, end.Format("2006-01-02 15:04"), res.Meta.End, "unexpected meta value for end")
+	//	assert.Equal(t, lat, res.Meta.Lat, "unexpected meta value for latitude")
+	//	assert.Equal(t, lng, res.Meta.Lng, "unexpected meta value for longitude")
+	//})
 }

--- a/integration_tests/waether_test.go
+++ b/integration_tests/waether_test.go
@@ -5,7 +5,10 @@ package integration_tests_test
 
 import (
 	"context"
+	"log"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/jinzhu/now"
 
@@ -39,33 +42,51 @@ func TestGetPoint(t *testing.T) {
 		assert.NotNil(t, err, "expecting non-nil error")
 		assert.Equal(t, "403: key:API key is invalid", err.Error(), "unexpected error")
 	})
-	//t.Run("success: return 24 hour points", func(t *testing.T) {
-	//	var start = now.BeginningOfDay()
-	//	var end = now.BeginningOfDay().Add(time.Hour * 23) // api returns hours ahead
-	//
-	//	c := stormglass.NewClient(os.Getenv("STORMGLASS_API_KEY"))
-	//
-	//	params := stormglass.ParamsOptions{
-	//		AirTemperature: true,
-	//	}
-	//
-	//	ctx := context.Background()
-	//	res, err := c.GetPoint(ctx, stormglass.PointsRequestOptions{
-	//		Lat:    lat,
-	//		Lng:    lng,
-	//		Params: params,
-	//		Start:  &start,
-	//		End:    &end,
-	//	})
-	//
-	//	assert.Nil(t, err, "expecting nil response")
-	//	assert.NotNil(t, res, "expecting non-nil response")
-	//	assert.Equal(t, 24, len(res.Hours), "unexpected hour point count")
-	//	assert.NotNil(t, res.Meta, "expecting non-nil response")
-	//	assert.Equal(t, res.Meta.Cost, 1, "unexpected meta value for cost")
-	//	assert.Equal(t, start.Format("2006-01-02 15:04"), res.Meta.Start, "unexpected meta value for start")
-	//	assert.Equal(t, end.Format("2006-01-02 15:04"), res.Meta.End, "unexpected meta value for end")
-	//	assert.Equal(t, lat, res.Meta.Lat, "unexpected meta value for latitude")
-	//	assert.Equal(t, lng, res.Meta.Lng, "unexpected meta value for longitude")
-	//})
+	t.Run("success: return 24 hour points", func(t *testing.T) {
+		tme := time.Now().In(time.UTC)
+		var start = now.New(tme).BeginningOfDay()
+		var end = now.New(tme).BeginningOfDay().Add(time.Hour * 23) // api returns hours ahead
+
+		loc := start.Location()
+		log.Println(loc)
+
+		c := stormglass.NewClient(os.Getenv("STORMGLASS_API_KEY"))
+
+		params := stormglass.ParamsOptions{
+			AirTemperature:   true,
+			WaveDirection:    true,
+			WaterTemperature: true,
+		}
+
+		sources := stormglass.SourcesOptions{
+			ICON:        true,
+			UKMetOffice: true,
+			StormGlass:  true,
+		}
+
+		ctx := context.Background()
+		res, err := c.GetPoint(ctx, stormglass.PointsRequestOptions{
+			Lat:    lat,
+			Lng:    lng,
+			Params: params,
+			Start:  &start,
+			End:    &end,
+			Source: sources,
+		})
+
+		assert.Nil(t, err, "expecting nil response")
+		assert.NotNil(t, res, "expecting non-nil response")
+		assert.Equal(t, 24, len(res.Hours), "unexpected hour point count")
+		assert.NotNil(t, res.Meta, "expecting non-nil response")
+		assert.Equal(t, res.Meta.Cost, 1, "unexpected meta value for cost")
+		assert.Equal(t, start.Format("2006-01-02 15:04"), res.Meta.Start, "unexpected meta value for start")
+		assert.Equal(t, end.Format("2006-01-02 15:04"), res.Meta.End, "unexpected meta value for end")
+		assert.Equal(t, lat, res.Meta.Lat, "unexpected meta value for latitude")
+		assert.Equal(t, lng, res.Meta.Lng, "unexpected meta value for longitude")
+		for _, h := range res.Hours {
+			assert.NotNil(t, h.AirTemperature, "expected air temperature to be set")
+			assert.NotNil(t, h.WaveDirection, "expected wave direction to be set")
+			assert.NotNil(t, h.WaterTemperature, "expected wave temperature to be set")
+		}
+	})
 }

--- a/integration_tests/waether_test.go
+++ b/integration_tests/waether_test.go
@@ -5,8 +5,9 @@ package integration_tests_test
 
 import (
 	"context"
-	"github.com/jinzhu/now"
 	"testing"
+
+	"github.com/jinzhu/now"
 
 	"github.com/stretchr/testify/assert"
 	stormglass "github.com/yawlhead91/stormglassgo"

--- a/weather_test.go
+++ b/weather_test.go
@@ -287,7 +287,7 @@ func TestClientGetPoint(t *testing.T) {
 
 		assert := assert.New(t)
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			want := `{"errors:{"unauthorized", "Unauthorized – Your API key is invalid."}}`
+			want := `{"errors:{"key", "Unauthorized – Your API key is invalid."}}`
 			w.WriteHeader(http.StatusUnauthorized)
 			w.Write([]byte(want))
 		}))


### PR DESCRIPTION
Add unit tests to the client and finish the integrations test.

These can be extended in the future to included more cases